### PR TITLE
Ignore port in host.

### DIFF
--- a/allow_cidr/middleware.py
+++ b/allow_cidr/middleware.py
@@ -32,9 +32,10 @@ class AllowCIDRMiddleware(MiddlewareMixin):
         if validate_host(host, ORIG_ALLOWED_HOSTS):
             return None
 
+        netloc = host.split(':', 1)[0]
         for net in self.allowed_cidr_nets:
             try:
-                if host in net:
+                if netloc in net:
                     return None
             except AddrFormatError:
                 # not an IP

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -25,6 +25,8 @@ class TestAllowCIDRMiddleware(TestCase):
         self.assertIsNone(mw.process_request(req))
         req = self.rf.get('/', HTTP_HOST='192.168.2.200')
         self.assertIsNone(mw.process_request(req))
+        req = self.rf.get('/', HTTP_HOST='192.168.2.200:8000')
+        self.assertIsNone(mw.process_request(req))
         with self.assertRaises(DisallowedHost):
             req = self.rf.get('/', HTTP_HOST='192.168.3.200')
             mw.process_request(req)


### PR DESCRIPTION
This will allow requests against 192.168.1.2:8000 to work when 192.168.1.2/24 is
in allowed cidrs. Matches Django behavior.