### PR TITLE
Split domain and port for all host headers

### DIFF
--- a/allow_cidr/middleware.py
+++ b/allow_cidr/middleware.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import DisallowedHost, MiddlewareNotUsed
-from django.http.request import validate_host
+from django.http.request import split_domain_port, validate_host
 
 from netaddr import AddrFormatError, IPNetwork
 
@@ -29,13 +29,13 @@ class AllowCIDRMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         host = request.get_host()
-        if validate_host(host, ORIG_ALLOWED_HOSTS):
+        domain, port = split_domain_port(host)
+        if domain and validate_host(domain, ORIG_ALLOWED_HOSTS):
             return None
 
-        netloc = host.split(':', 1)[0]
         for net in self.allowed_cidr_nets:
             try:
-                if netloc in net:
+                if domain in net:
                     return None
             except AddrFormatError:
                 # not an IP

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -40,6 +40,8 @@ class TestAllowCIDRMiddleware(TestCase):
         self.assertIsNone(mw.process_request(req))
         req = self.rf.get('/', HTTP_HOST='thebig.lebowski.biz')
         self.assertIsNone(mw.process_request(req))
+        req = self.rf.get('/', HTTP_HOST='thebig.lebowski.biz:8000')
+        self.assertIsNone(mw.process_request(req))
         with self.assertRaises(DisallowedHost):
             req = self.rf.get('/', HTTP_HOST='donnie.net')
             mw.process_request(req)


### PR DESCRIPTION
This is how Django does it in request.get_host()