### PR TITLE
Fix typo enalbe -> enable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Django Allow CIDR
 .. image:: https://travis-ci.org/mozmeao/django-allow-cidr.svg?branch=master
     :target: https://travis-ci.org/mozmeao/django-allow-cidr
 
-A Django Middleware to enalbe use of CIDR IP ranges in ALLOWED_HOSTS.
+A Django Middleware to enable use of CIDR IP ranges in ALLOWED_HOSTS.
 
 Quickstart
 ----------

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 setup(
     name='django-allow-cidr',
     version=version,
-    description="""A Django Middleware to enalbe use of CIDR IP ranges in ALLOWED_HOSTS.""",
+    description="""A Django Middleware to enable use of CIDR IP ranges in ALLOWED_HOSTS.""",
     long_description=readme + '\n\n' + history,
     author='Paul McLanahan',
     author_email='pmac@mozilla.com',


### PR DESCRIPTION
This typo is also in the GitHub repo description. Sorry :). But thanks, this project is exactly what I needed.