### PR TITLE
Use packaging.version to avoid distutils deprecated module

### DIFF
--- a/allow_cidr/middleware.py
+++ b/allow_cidr/middleware.py
@@ -1,4 +1,7 @@
-from distutils.version import StrictVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import StrictVersion as Version
 
 import django
 from django.conf import settings
@@ -14,7 +17,7 @@ class AllowCIDRMiddleware:
 
         self.get_response = get_response
 
-        if StrictVersion(django.get_version()) < StrictVersion("2.2"):
+        if Version(django.get_version()) < Version("2.2"):
             raise NotImplementedError(
                 "This version of django-allow-cidr requires at least Django 2.2"
             )

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     install_requires=[
         "Django>=2.2",
         "netaddr>=0.7.19",
+        "packaging",
     ],
     license="Apache Software License 2.0",
     zip_safe=False,


### PR DESCRIPTION
PEP 632 [0] documents the deprecation of te Python module `distutils` since Python 3.10, with its complete removal in Python 3.12.

This change starts using `packaging.version` instead, but maintains the `distutils` fallback to follow the same pattern as the `setuptools.setup` usage found in the `setup.py` file.

Also, we add `packaging` as an installation requirement, so we can completely avoid `distutils` even in older Python versions.

Closes #16

[0] https://peps.python.org/pep-0632/