### PR TITLE
Add Django 4.1, 4.2, and 5.0 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
         django-tox-env:
           - "django22"
@@ -24,6 +25,7 @@ jobs:
           - "django40"
           - "django41"
           - "django42"
+          - "django50"
 
         exclude:
           # We don't want every combination of the above, as some are not compatible
@@ -37,11 +39,29 @@ jobs:
           - python-version: "3.7"
             django-tox-env: "django42"
 
+          - python-version: "3.7"
+            django-tox-env: "django50"
+
+          - python-version: "3.8"
+            django-tox-env: "django50"
+
+          - python-version: "3.9"
+            django-tox-env: "django50"
+
           - python-version: "3.10"
             django-tox-env: "django22"
 
           - python-version: "3.11"
             django-tox-env: "django22"
+
+          - python-version: "3.11"
+            django-tox-env: "django40"
+
+          - python-version: "3.12"
+            django-tox-env: "django40"
+
+          - python-version: "3.12"
+            django-tox-env: "django41"
 
     name: Python ${{ matrix.python-version }} in use with ${{ matrix.django-tox-env }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           - python-version: "3.11"
             django-tox-env: "django22"
 
+          - python-version: "3.12"
+            django-tox-env: "django22"
+
           - python-version: "3.11"
             django-tox-env: "django40"
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Steve Jalim <opensource@stevejalim.mozmail.com>
 * Michael Manganiello - https://github.com/adamantike
 * Ningú - https://github.com/n1ngu
+* blag - https://github.com/blag

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ envlist =
     {py3.6,py3.7,py3.8,py3.9}-django22
     {py3.6,py3.7,py3.8,py3.9,py3.10}-django32
     {py3.8,py3.9,py3.10}-django40
+    {py3.8,py3.9,py3.10,py3.11}-django41
+    {py3.8,py3.9,py3.10,py3.11,3.12}-django42
+    {py3.10,py3.11,3.12}-django50
     py3.9-flake8
 
 [testenv]
@@ -12,8 +15,13 @@ commands = python runtests.py
 deps =
     django22: Django>=2.2,<2.3
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<5.0
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
 basepython =
+    py3.12: python3.12
+    py3.11: python3.11
     py3.10: python3.10
     py3.9: python3.9
     py3.8: python3.8


### PR DESCRIPTION
I also added Python 3.11 to the tox config and Python 3.12 to the test matrix.